### PR TITLE
LPS-X When the header instance is created, if the value is null, the …

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/MetaInfoCacheServletResponse.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/MetaInfoCacheServletResponse.java
@@ -514,13 +514,15 @@ public class MetaInfoCacheServletResponse extends HttpServletResponseWrapper {
 			return;
 		}
 
-		Set<Header> values = new HashSet<>();
+		if (value != null) {
+			Set<Header> values = new HashSet<>();
 
-		_metaData._headers.put(name, values);
+			_metaData._headers.put(name, values);
 
-		Header header = new Header(value);
+			Header header = new Header(value);
 
-		values.add(header);
+			values.add(header);
+		}
 
 		super.setHeader(name, value);
 	}


### PR DESCRIPTION
…IllegalArgumentException exception will be thrown.