### PR TITLE
LPS-X Not used at all

### DIFF
--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/PropsInvocationHandler.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/PropsInvocationHandler.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.cache.ehcache.internal.configurator;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.PropsKeys;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import java.util.Properties;
+
+/**
+ * @author Leon Chi
+ */
+public class PropsInvocationHandler implements InvocationHandler {
+
+	public static final String[]
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT_VALUE =
+			{"value5", "value6"};
+
+	public static final String[] EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE =
+		{"value7", "value8"};
+
+	public static final String EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE =
+		"ehcache.rmi.peer.listener.factory.class.value";
+
+	public static final String[]
+		EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE =
+			{"value1", "value2"};
+
+	public static final String EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE =
+		"ehcache.rmi.peer.provider.factory.class.value";
+
+	public static final String[]
+		EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE =
+			{"value3", "value4"};
+
+	public PropsInvocationHandler() {
+		this(true);
+	}
+
+	public PropsInvocationHandler(boolean clusterEnabled) {
+		_clusterEnabled = clusterEnabled;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) {
+		String methodName = method.getName();
+
+		if (methodName.equals("get")) {
+			String key = (String)args[0];
+
+			if (PropsKeys.EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS.equals(key)) {
+				return EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS.equals(key)) {
+				return EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE;
+			}
+
+			if (PropsKeys.CLUSTER_LINK_ENABLED.equals(key)) {
+				if (_clusterEnabled) {
+					return "true";
+				}
+				else {
+					return "false";
+				}
+			}
+		}
+
+		if (methodName.equals("getArray")) {
+			String key = (String)args[0];
+
+			if (PropsKeys.EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES.equals(
+					key)) {
+
+				return EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES.equals(
+					key)) {
+
+				return EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT.
+					equals(key)) {
+
+				return EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_REPLICATOR_PROPERTIES_DEFAULT.equals(key)) {
+				return EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE;
+			}
+		}
+
+		if (methodName.equals("getProperties")) {
+			String key = (String)args[0];
+
+			if (key.equals(
+					PropsKeys.EHCACHE_REPLICATOR_PROPERTIES +
+						StringPool.PERIOD)) {
+
+				return new Properties();
+			}
+		}
+
+		return null;
+	}
+
+	private boolean _clusterEnabled;
+
+}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/PropsInvocationHandler.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/PropsInvocationHandler.java
@@ -48,10 +48,6 @@ public class PropsInvocationHandler implements InvocationHandler {
 		EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE =
 			{"value3", "value4"};
 
-	public PropsInvocationHandler() {
-		this(true);
-	}
-
 	public PropsInvocationHandler(boolean clusterEnabled) {
 		_clusterEnabled = clusterEnabled;
 	}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.cache.ehcache.internal.configurator;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.cache.configuration.PortalCacheManagerConfiguration;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import java.util.List;
+
+import net.sf.ehcache.config.Configuration;
+import net.sf.ehcache.config.FactoryConfiguration;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Leon Chi
+ */
+public class RMIMultiVMEhcachePortalCacheManagerConfiguratorTest {
+
+	@ClassRule
+	public static final CodeCoverageAssertor codeCoverageAssertor =
+		CodeCoverageAssertor.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+	}
+
+	@Before
+	public void setUp() {
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator =
+			new RMIMultiVMEhcachePortalCacheManagerConfigurator();
+	}
+
+	@After
+	public void tearDown() {
+	}
+
+	@Test
+	public void testActivate() {
+		_activate(false);
+
+		String peerListenerFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerListenerFactoryClass");
+		String peerListenerFactoryPropertiesString =
+			ReflectionTestUtil.getFieldValue(
+				_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+				"_peerListenerFactoryPropertiesString");
+		String peerProviderFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerProviderFactoryClass");
+		String peerProviderFactoryPropertiesString =
+			ReflectionTestUtil.getFieldValue(
+				_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+				"_peerProviderFactoryPropertiesString");
+
+		Assert.assertNull(peerListenerFactoryClass);
+		Assert.assertNull(peerListenerFactoryPropertiesString);
+		Assert.assertNull(peerProviderFactoryClass);
+		Assert.assertNull(peerProviderFactoryPropertiesString);
+
+		_activate(true);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.activate();
+
+		peerListenerFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerListenerFactoryClass");
+		peerListenerFactoryPropertiesString = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerListenerFactoryPropertiesString");
+		peerProviderFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerProviderFactoryClass");
+		peerProviderFactoryPropertiesString = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerProviderFactoryPropertiesString");
+
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE,
+			peerProviderFactoryClass);
+		Assert.assertEquals(
+			_getPortalPropertiesString(
+				PropsInvocationHandler.
+					EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE),
+			peerListenerFactoryPropertiesString);
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE,
+			peerListenerFactoryClass);
+		Assert.assertEquals(
+			_getPortalPropertiesString(
+				PropsInvocationHandler.
+					EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE),
+			peerProviderFactoryPropertiesString);
+	}
+
+	@Test
+	public void testManageConfiguration() {
+		Configuration configuration = new Configuration();
+
+		PortalCacheManagerConfiguration portalCacheManagerConfiguration =
+			new PortalCacheManagerConfiguration(null, null, null);
+
+		_activate(false);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				configuration.
+					getCacheManagerPeerProviderFactoryConfiguration()));
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				configuration.
+					getCacheManagerPeerListenerFactoryConfigurations()));
+
+		_activate(true);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		List<FactoryConfiguration>
+			cacheManagerPeerProviderFactoryConfigurationLsit =
+				configuration.getCacheManagerPeerProviderFactoryConfiguration();
+
+		FactoryConfiguration peerProviderFactoryConfiguration =
+			cacheManagerPeerProviderFactoryConfigurationLsit.get(0);
+
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE,
+			peerProviderFactoryConfiguration.getFullyQualifiedClassPath());
+		Assert.assertEquals(
+			_getPortalPropertiesString(
+				PropsInvocationHandler.
+					EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE),
+			peerProviderFactoryConfiguration.getProperties());
+		Assert.assertSame(
+			StringPool.COMMA,
+			peerProviderFactoryConfiguration.getPropertySeparator());
+
+		List<FactoryConfiguration>
+			cacheManagerPeerListenerFactoryConfigurations =
+				configuration.
+					getCacheManagerPeerListenerFactoryConfigurations();
+
+		FactoryConfiguration peerListenerFacotryConfiguration =
+			cacheManagerPeerListenerFactoryConfigurations.get(0);
+
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE,
+			peerListenerFacotryConfiguration.getFullyQualifiedClassPath());
+		Assert.assertEquals(
+			_getPortalPropertiesString(
+				PropsInvocationHandler.
+					EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE),
+			peerListenerFacotryConfiguration.getProperties());
+		Assert.assertSame(
+			StringPool.COMMA,
+			peerListenerFacotryConfiguration.getPropertySeparator());
+	}
+
+	private void _activate(boolean clusterEnabled) {
+		Props proxyProps = (Props)ProxyUtil.newProxyInstance(
+			_classLoader, new Class<?>[] {Props.class},
+			new PropsInvocationHandler(clusterEnabled));
+
+		ReflectionTestUtil.setFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator, "props",
+			proxyProps);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.activate();
+	}
+
+	private String _getPortalPropertiesString(String[] array) {
+		if (array.length == 0) {
+			return null;
+		}
+
+		if (array.length == 1) {
+			return array[0];
+		}
+
+		StringBundler sb = new StringBundler(array.length * 2);
+
+		for (String value : array) {
+			sb.append(value);
+			sb.append(StringPool.COMMA);
+		}
+
+		sb.setIndex(sb.index() - 1);
+
+		return sb.toString();
+	}
+
+	private static final ClassLoader _classLoader =
+		RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.class.
+			getClassLoader();
+
+	private RMIMultiVMEhcachePortalCacheManagerConfigurator
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator;
+
+}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -89,8 +89,6 @@ public class RMIMultiVMEhcachePortalCacheManagerConfiguratorTest {
 
 		_activate(true);
 
-		_rmiMultiVMEhcachePortalCacheManagerConfigurator.activate();
-
 		peerListenerFactoryClass = ReflectionTestUtil.getFieldValue(
 			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
 			"_peerListenerFactoryClass");

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -197,9 +197,7 @@ public class RMIMultiVMEhcachePortalCacheManagerConfiguratorTest {
 			_classLoader, new Class<?>[] {Props.class},
 			new PropsInvocationHandler(clusterEnabled));
 
-		ReflectionTestUtil.setFieldValue(
-			_rmiMultiVMEhcachePortalCacheManagerConfigurator, "props",
-			proxyProps);
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.setProps(proxyProps);
 
 		_rmiMultiVMEhcachePortalCacheManagerConfigurator.activate();
 	}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.StringBundler;
 
 import java.util.List;
 
+import com.liferay.portal.kernel.util.StringUtil;
 import net.sf.ehcache.config.Configuration;
 import net.sf.ehcache.config.FactoryConfiguration;
 
@@ -201,24 +202,7 @@ public class RMIMultiVMEhcachePortalCacheManagerConfiguratorTest {
 	}
 
 	private String _getPortalPropertiesString(String[] array) {
-		if (array.length == 0) {
-			return null;
-		}
-
-		if (array.length == 1) {
-			return array[0];
-		}
-
-		StringBundler sb = new StringBundler(array.length * 2);
-
-		for (String value : array) {
-			sb.append(value);
-			sb.append(StringPool.COMMA);
-		}
-
-		sb.setIndex(sb.index() - 1);
-
-		return sb.toString();
+		return StringUtil.merge(array, StringPool.COMMA);
 	}
 
 	private static final ClassLoader _classLoader =


### PR DESCRIPTION
@ChiZeLin The method _getPortalPropertiesString does the almost the same thing as StringUtil.merge(Object[], String), plz remove that method.