### PR TITLE
LPS-X You mean to check method1, right? This behavior of MethodCache may also need some discussion

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodCacheTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodCacheTest.java
@@ -57,7 +57,7 @@ public class MethodCacheTest {
 		Method method1 = MethodCache.get(publicMethodKey);
 
 		Assert.assertSame(method, method1);
-		Assert.assertFalse(method.isAccessible());
+		Assert.assertFalse(method1.isAccessible());
 		Assert.assertEquals(methods.toString(), 1, methods.size());
 
 		MethodCache.reset();

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodCacheTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodCacheTest.java
@@ -45,12 +45,11 @@ public class MethodCacheTest {
 			MethodCache.class, "_methods");
 
 		MethodKey publicMethodKey = new MethodKey(
-			TestMethodCache.class, "publicMethod", String.class);
+			TestClass.class, "publicMethod", String.class);
 
 		Method method = MethodCache.get(publicMethodKey);
 
 		Assert.assertTrue(method.isAccessible());
-
 		Assert.assertEquals(methods.toString(), 1, methods.size());
 
 		method.setAccessible(false);
@@ -58,7 +57,6 @@ public class MethodCacheTest {
 		Method method1 = MethodCache.get(publicMethodKey);
 
 		Assert.assertSame(method, method1);
-
 		Assert.assertFalse(method.isAccessible());
 		Assert.assertEquals(methods.toString(), 1, methods.size());
 
@@ -67,7 +65,7 @@ public class MethodCacheTest {
 		Assert.assertEquals(methods.toString(), 0, methods.size());
 	}
 
-	private class TestMethodCache {
+	private class TestClass {
 
 		public void publicMethod(String string) {
 		}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodCacheTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodCacheTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+
+import java.lang.reflect.Method;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Leon Chi
+ */
+public class MethodCacheTest {
+
+	@ClassRule
+	public static final CodeCoverageAssertor codeCoverageAssertor =
+		CodeCoverageAssertor.INSTANCE;
+
+	@Test
+	public void testConstructor() {
+		new MethodCache();
+	}
+
+	@Test
+	public void testGetAndReset() throws NoSuchMethodException {
+		Map<MethodKey, Method> methods = ReflectionTestUtil.getFieldValue(
+			MethodCache.class, "_methods");
+
+		MethodKey publicMethodKey = new MethodKey(
+			TestMethodCache.class, "publicMethod", String.class);
+
+		Method method = MethodCache.get(publicMethodKey);
+
+		Assert.assertTrue(method.isAccessible());
+
+		Assert.assertEquals(methods.toString(), 1, methods.size());
+
+		method.setAccessible(false);
+
+		Method method1 = MethodCache.get(publicMethodKey);
+
+		Assert.assertSame(method, method1);
+
+		Assert.assertFalse(method.isAccessible());
+		Assert.assertEquals(methods.toString(), 1, methods.size());
+
+		MethodCache.reset();
+
+		Assert.assertEquals(methods.toString(), 0, methods.size());
+	}
+
+	private class TestMethodCache {
+
+		public void publicMethod(String string) {
+		}
+
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -119,11 +119,16 @@ public class MethodKeyTest {
 		throws IllegalAccessException, InvocationTargetException,
 			   NoSuchMethodException {
 
-		Method method = _methodKey.getMethod();
+		Method expectedMethod = TestClass1.class.getMethod(
+			"testMethod", String.class);
+
+		Method actualMethod = _methodKey.getMethod();
+
+		Assert.assertEquals(expectedMethod, actualMethod);
 
 		TestClass1 testClass = new TestClass1();
 
-		String result = (String)method.invoke(testClass, "test");
+		String result = (String)actualMethod.invoke(testClass, "test");
 
 		Assert.assertEquals("test", result);
 	}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -90,9 +90,9 @@ public class MethodKeyTest {
 	public void testEquals() {
 		Assert.assertTrue(_methodKey.equals(_methodKey));
 
-		TestClass1 testClass = new TestClass1();
+		Object object = new Object();
 
-		Assert.assertFalse(_methodKey.equals(testClass));
+		Assert.assertFalse(_methodKey.equals(object));
 
 		MethodKey methodKey = new MethodKey(
 			TestClass1.class, "testMethod", String.class);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Leon Chi
+ */
+public class MethodKeyTest {
+
+	@ClassRule
+	public static final CodeCoverageAssertor codeCoverageAssertor =
+		CodeCoverageAssertor.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_methodKey = new MethodKey(_clazz, "testMethod", String.class);
+	}
+
+	@Test
+	public void testConstructors() throws NoSuchMethodException {
+		Assert.assertEquals(_clazz, _methodKey.getDeclaringClass());
+		Assert.assertEquals("testMethod", _methodKey.getMethodName());
+		Assert.assertEquals(String.class, _methodKey.getParameterTypes()[0]);
+
+		MethodKey methodKey = new MethodKey();
+
+		Assert.assertNull(methodKey.getDeclaringClass());
+		Assert.assertNull(methodKey.getMethodName());
+		Assert.assertNull(methodKey.getParameterTypes());
+
+		Method method = _clazz.getMethod("testMethod", String.class);
+
+		methodKey = new MethodKey(method);
+
+		Assert.assertEquals(_clazz, methodKey.getDeclaringClass());
+		Assert.assertEquals("testMethod", methodKey.getMethodName());
+		Assert.assertEquals(String.class, methodKey.getParameterTypes()[0]);
+
+		methodKey = new MethodKey(
+			"com.liferay.portal.kernel.util.MethodKeyTest$TestMethodKey",
+			"testMethod", String.class);
+
+		Assert.assertEquals(_clazz, methodKey.getDeclaringClass());
+		Assert.assertEquals("testMethod", methodKey.getMethodName());
+		Assert.assertEquals(String.class, methodKey.getParameterTypes()[0]);
+
+		try {
+			new MethodKey("ClassNotFound", "testMethod", String.class);
+			Assert.fail("No RuntimeException throw!");
+		}
+		catch (RuntimeException re) {
+			Assert.assertTrue(true);
+		}
+	}
+
+	@Test
+	public void testEquals() {
+		Assert.assertTrue(_methodKey.equals(_methodKey));
+
+		TestMethodKey testMethodKey = new TestMethodKey();
+
+		Assert.assertFalse(_methodKey.equals(testMethodKey));
+
+		MethodKey methodKey = new MethodKey(_clazz, "testMethod", String.class);
+
+		Assert.assertTrue(_methodKey.equals(methodKey));
+
+		methodKey = new MethodKey(_clazz, "testMethod", int.class);
+
+		Assert.assertFalse(_methodKey.equals(methodKey));
+
+		methodKey = new MethodKey(_clazz, "testMethod1", String.class);
+
+		Assert.assertFalse(_methodKey.equals(methodKey));
+
+		methodKey = new MethodKey(
+			TestMethodKey1.class, "testMethod", String.class);
+
+		Assert.assertFalse(_methodKey.equals(methodKey));
+	}
+
+	@Test
+	public void testGetMethod()
+		throws IllegalAccessException, InvocationTargetException,
+			   NoSuchMethodException {
+
+		Method method = _methodKey.getMethod();
+		TestMethodKey testMethodKey = new TestMethodKey();
+
+		String result = (String)method.invoke(testMethodKey, "test");
+
+		Assert.assertEquals("test", result);
+	}
+
+	@Test
+	public void testHashCode() throws NoSuchMethodException {
+		Method method = _clazz.getMethod("testMethod", String.class);
+
+		Assert.assertEquals(method.hashCode(), _methodKey.hashCode());
+	}
+
+	@Test
+	public void testToString() {
+		Assert.assertEquals(
+			"com.liferay.portal.kernel.util.MethodKeyTest$TestMethodKey." +
+				"testMethod(java.lang.String)",
+			_methodKey.toString());
+
+		MethodKey methodKey = new MethodKey(_clazz, "testMethod", String.class);
+
+		ReflectionTestUtil.setFieldValue(methodKey, "_toString", "testString");
+
+		Assert.assertEquals("testString", methodKey.toString());
+	}
+
+	@Test
+	public void testTransform() throws ClassNotFoundException {
+		Thread currentThread = Thread.currentThread();
+
+		ClassLoader classLoader = currentThread.getContextClassLoader();
+
+		MethodKey methodKey = _methodKey.transform(classLoader);
+
+		Assert.assertTrue(_methodKey.equals(methodKey));
+	}
+
+	@Test
+	public void testWriteAndReadExternal()
+		throws ClassNotFoundException, IOException {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		ObjectOutputStream objectOutputStream = new ObjectOutputStream(
+			byteArrayOutputStream);
+
+		_methodKey.writeExternal(objectOutputStream);
+
+		objectOutputStream.close();
+
+		ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(
+			byteArrayOutputStream.toByteArray());
+
+		ObjectInputStream objectInputStream = new ObjectInputStream(
+			byteArrayInputStream);
+
+		MethodKey methodKey = new MethodKey();
+
+		methodKey.readExternal(objectInputStream);
+
+		objectInputStream.close();
+
+		Assert.assertTrue(_methodKey.equals(methodKey));
+	}
+
+	private final Class<?> _clazz = TestMethodKey.class;
+	private MethodKey _methodKey;
+
+	private class TestMethodKey {
+
+		public void testMethod(int string) {
+		}
+
+		public String testMethod(String string) {
+			return string;
+		}
+
+		public void testMethod1(String string) {
+		}
+
+	}
+
+	private class TestMethodKey1 {
+
+		public void testMethod(String string) {
+		}
+
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -146,13 +146,14 @@ public class MethodKeyTest {
 			"com.liferay.portal.kernel.util.MethodKeyTest$TestMethodKey." +
 				"testMethod(java.lang.String)",
 			_methodKey.toString());
+		Assert.assertEquals(
+			"com.liferay.portal.kernel.util.MethodKeyTest$TestMethodKey." +
+				"testMethod(java.lang.String)",
+			ReflectionTestUtil.getFieldValue(_methodKey, "_toString"));
 
-		MethodKey methodKey = new MethodKey(
-			TestClass1.class, "testMethod", String.class);
+		ReflectionTestUtil.setFieldValue(_methodKey, "_toString", "testString");
 
-		ReflectionTestUtil.setFieldValue(methodKey, "_toString", "testString");
-
-		Assert.assertEquals("testString", methodKey.toString());
+		Assert.assertEquals("testString", _methodKey.toString());
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -42,12 +42,13 @@ public class MethodKeyTest {
 
 	@Before
 	public void setUp() {
-		_methodKey = new MethodKey(_clazz, "testMethod", String.class);
+		_methodKey = new MethodKey(
+			TestClass1.class, "testMethod", String.class);
 	}
 
 	@Test
 	public void testConstructors() throws NoSuchMethodException {
-		Assert.assertEquals(_clazz, _methodKey.getDeclaringClass());
+		Assert.assertEquals(TestClass1.class, _methodKey.getDeclaringClass());
 		Assert.assertEquals("testMethod", _methodKey.getMethodName());
 		Assert.assertEquals(String.class, _methodKey.getParameterTypes()[0]);
 
@@ -57,11 +58,11 @@ public class MethodKeyTest {
 		Assert.assertNull(methodKey.getMethodName());
 		Assert.assertNull(methodKey.getParameterTypes());
 
-		Method method = _clazz.getMethod("testMethod", String.class);
+		Method method = TestClass1.class.getMethod("testMethod", String.class);
 
 		methodKey = new MethodKey(method);
 
-		Assert.assertEquals(_clazz, methodKey.getDeclaringClass());
+		Assert.assertEquals(TestClass1.class, methodKey.getDeclaringClass());
 		Assert.assertEquals("testMethod", methodKey.getMethodName());
 		Assert.assertEquals(String.class, methodKey.getParameterTypes()[0]);
 
@@ -69,12 +70,13 @@ public class MethodKeyTest {
 			"com.liferay.portal.kernel.util.MethodKeyTest$TestMethodKey",
 			"testMethod", String.class);
 
-		Assert.assertEquals(_clazz, methodKey.getDeclaringClass());
+		Assert.assertEquals(TestClass1.class, methodKey.getDeclaringClass());
 		Assert.assertEquals("testMethod", methodKey.getMethodName());
 		Assert.assertEquals(String.class, methodKey.getParameterTypes()[0]);
 
 		try {
 			new MethodKey("ClassNotFound", "testMethod", String.class);
+
 			Assert.fail("No RuntimeException throw!");
 		}
 		catch (RuntimeException re) {
@@ -86,24 +88,26 @@ public class MethodKeyTest {
 	public void testEquals() {
 		Assert.assertTrue(_methodKey.equals(_methodKey));
 
-		TestMethodKey testMethodKey = new TestMethodKey();
+		TestClass1 testClass = new TestClass1();
 
-		Assert.assertFalse(_methodKey.equals(testMethodKey));
+		Assert.assertFalse(_methodKey.equals(testClass));
 
-		MethodKey methodKey = new MethodKey(_clazz, "testMethod", String.class);
+		MethodKey methodKey = new MethodKey(
+			TestClass1.class, "testMethod", String.class);
 
 		Assert.assertTrue(_methodKey.equals(methodKey));
 
-		methodKey = new MethodKey(_clazz, "testMethod", int.class);
-
-		Assert.assertFalse(_methodKey.equals(methodKey));
-
-		methodKey = new MethodKey(_clazz, "testMethod1", String.class);
+		methodKey = new MethodKey(TestClass1.class, "testMethod", int.class);
 
 		Assert.assertFalse(_methodKey.equals(methodKey));
 
 		methodKey = new MethodKey(
-			TestMethodKey1.class, "testMethod", String.class);
+			TestClass1.class, "testMethod1", String.class);
+
+		Assert.assertFalse(_methodKey.equals(methodKey));
+
+		methodKey = new MethodKey(
+			TestClass2.class, "testMethod", String.class);
 
 		Assert.assertFalse(_methodKey.equals(methodKey));
 	}
@@ -114,16 +118,17 @@ public class MethodKeyTest {
 			   NoSuchMethodException {
 
 		Method method = _methodKey.getMethod();
-		TestMethodKey testMethodKey = new TestMethodKey();
 
-		String result = (String)method.invoke(testMethodKey, "test");
+		TestClass1 testClass = new TestClass1();
+
+		String result = (String)method.invoke(testClass, "test");
 
 		Assert.assertEquals("test", result);
 	}
 
 	@Test
 	public void testHashCode() throws NoSuchMethodException {
-		Method method = _clazz.getMethod("testMethod", String.class);
+		Method method = TestClass1.class.getMethod("testMethod", String.class);
 
 		Assert.assertEquals(method.hashCode(), _methodKey.hashCode());
 	}
@@ -135,7 +140,8 @@ public class MethodKeyTest {
 				"testMethod(java.lang.String)",
 			_methodKey.toString());
 
-		MethodKey methodKey = new MethodKey(_clazz, "testMethod", String.class);
+		MethodKey methodKey = new MethodKey(
+			TestClass1.class, "testMethod", String.class);
 
 		ReflectionTestUtil.setFieldValue(methodKey, "_toString", "testString");
 
@@ -182,26 +188,25 @@ public class MethodKeyTest {
 		Assert.assertTrue(_methodKey.equals(methodKey));
 	}
 
-	private final Class<?> _clazz = TestMethodKey.class;
 	private MethodKey _methodKey;
 
-	private class TestMethodKey {
+	private class TestClass1 {
 
-		public void testMethod(int string) {
+		public void testMethod(int parameter) {
 		}
 
-		public String testMethod(String string) {
-			return string;
+		public String testMethod(String parameter) {
+			return parameter;
 		}
 
-		public void testMethod1(String string) {
+		public void testMethod1(String parameter) {
 		}
 
 	}
 
-	private class TestMethodKey1 {
+	private class TestClass2 {
 
-		public void testMethod(String string) {
+		public void testMethod(String parameter) {
 		}
 
 	}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -108,8 +108,7 @@ public class MethodKeyTest {
 
 		Assert.assertFalse(_methodKey.equals(methodKey));
 
-		methodKey = new MethodKey(
-			TestClass2.class, "testMethod", String.class);
+		methodKey = new MethodKey(TestClass2.class, "testMethod", String.class);
 
 		Assert.assertFalse(_methodKey.equals(methodKey));
 	}
@@ -174,7 +173,7 @@ public class MethodKeyTest {
 		MethodKey methodKey = new MethodKey();
 
 		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-				 new UnsyncByteArrayOutputStream()) {
+				new UnsyncByteArrayOutputStream()) {
 
 			try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(
 					unsyncByteArrayOutputStream)) {
@@ -184,10 +183,10 @@ public class MethodKeyTest {
 
 			try (UnsyncByteArrayInputStream unsyncByteArrayInputStream =
 					new UnsyncByteArrayInputStream(
-						unsyncByteArrayOutputStream.unsafeGetByteArray(),
-						0, unsyncByteArrayOutputStream.size());
+						unsyncByteArrayOutputStream.unsafeGetByteArray(), 0,
+						unsyncByteArrayOutputStream.size());
 				ObjectInputStream objectInputStream = new ObjectInputStream(
-				 	unsyncByteArrayInputStream)) {
+					unsyncByteArrayInputStream)) {
 
 				methodKey.readExternal(objectInputStream);
 			}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/MethodKeyTest.java
@@ -80,7 +80,9 @@ public class MethodKeyTest {
 			Assert.fail("No RuntimeException throw!");
 		}
 		catch (RuntimeException re) {
-			Assert.assertTrue(true);
+			Throwable throwable = re.getCause();
+
+			Assert.assertTrue(throwable instanceof ClassNotFoundException);
 		}
 	}
 


### PR DESCRIPTION
@ChiZeLin Please read my changes, and run the test to make sure I didn't break anything. Also, for MethodKey.transform, since it involves class loader handling, shouldn't you at least use something like NewEnv.ClassLoader rule?