### PR TITLE
LPS-84188 Sort, I think this is more clear

### DIFF
--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -117,7 +117,7 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 				_multiVMEhcachePortalCacheManagerConfigurator,
 				"_getMergedPropertiesMap", null, null);
 
-		Assert.assertTrue(MapUtil.isEmpty(mergedPropertiesMap));
+		Assert.assertTrue(mergedPropertiesMap.isEmpty());
 
 		// Test 2: _bootstrapLoaderEnabled is true, _bootstrapLoaderProperties
 		// and _replicatorProperties are non-empty

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -83,11 +83,12 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 			"_replicatorProperties");
 
 		Assert.assertTrue(bootstrapLoaderEnabled);
+		Assert.assertTrue(clusterEnabled);
+
 		Assert.assertEquals(
 			PropsInvocationHandler.
 				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE,
 			bootstrapLoaderProperties);
-		Assert.assertTrue(clusterEnabled);
 		Assert.assertEquals(
 			StringUtil.merge(
 				PropsInvocationHandler.

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -858,26 +858,26 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 
 	@Test
 	public void testSetProps() {
-		Props proxyProps = (Props)ProxyUtil.newProxyInstance(
+		Props props = (Props)ProxyUtil.newProxyInstance(
 			_classLoader, new Class<?>[] {Props.class},
 			new PropsInvocationHandler(true, true));
 
-		_multiVMEhcachePortalCacheManagerConfigurator.setProps(proxyProps);
+		_multiVMEhcachePortalCacheManagerConfigurator.setProps(props);
 
 		Props proxy = ReflectionTestUtil.getFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator, "props");
 
-		Assert.assertSame(proxyProps, proxy);
+		Assert.assertSame(props, proxy);
 	}
 
 	private void _activate(
 		boolean clusterEnabled, boolean bootstrapLoaderEnabled) {
 
-		Props proxyProps = (Props)ProxyUtil.newProxyInstance(
+		Props props = (Props)ProxyUtil.newProxyInstance(
 			_classLoader, new Class<?>[] {Props.class},
 			new PropsInvocationHandler(clusterEnabled, bootstrapLoaderEnabled));
 
-		_multiVMEhcachePortalCacheManagerConfigurator.setProps(proxyProps);
+		_multiVMEhcachePortalCacheManagerConfigurator.setProps(props);
 
 		_multiVMEhcachePortalCacheManagerConfigurator.activate();
 	}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -109,9 +109,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 	public void testGetMergedPropertiesMap() {
 		_activate(true, true);
 
-		// test case1: _bootstrapLoaderEnabled is true,
-		// _bootstrapLoaderProperties and _replicatorProperties are both setted
-		// an empty properties
+		// Test 1: _bootstrapLoaderEnabled is true, _bootstrapLoaderProperties
+		// and _replicatorProperties are empty
 
 		Map<String, ObjectValuePair<Properties, Properties>>
 			mergedPropertiesMap = ReflectionTestUtil.invoke(
@@ -120,9 +119,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 
 		Assert.assertTrue(MapUtil.isEmpty(mergedPropertiesMap));
 
-		// test case2: _bootstrapLoaderEnabled is true,
-		// _bootstrapLoaderProperties and _replicatorProperties are both setted
-		// a non-empty properties
+		// Test 2: _bootstrapLoaderEnabled is true, _bootstrapLoaderProperties
+		// and _replicatorProperties are non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -182,9 +180,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 			Assert.assertTrue((boolean)valueProperties.get("replicator"));
 		}
 
-		// test case3: _bootstrapLoaderEnabled is true,
-		// _bootstrapLoaderProperties is setted an empty properties,
-		// _replicatorProperties is setted a non-empty properties
+		// Test 3: _bootstrapLoaderEnabled is true, _bootstrapLoaderProperties
+		// is empty, _replicatorProperties is non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -237,9 +234,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 			Assert.assertTrue((boolean)valueProperties.get("replicator"));
 		}
 
-		// test case4: _bootstrapLoaderEnabled is false,
-		// _bootstrapLoaderProperties and _replicatorProperties are both setted
-		// a non-empty properties
+		// Test 4: _bootstrapLoaderEnabled is false, _bootstrapLoaderProperties
+		// and _replicatorProperties are non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -342,7 +338,7 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 	public void testManageConfiguration() {
 		_activate(false, true);
 
-		// test case1: clusterEnabled is false
+		// Test 1: clusterEnabled is false
 
 		Configuration configuration = new Configuration();
 
@@ -368,7 +364,7 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 
 		Assert.assertFalse(calledGetDefaultPortalCacheConfiguration.get());
 
-		// test case2: clusterEnabled is true, mergedPropertiesMap is empty
+		// Test 2: clusterEnabled is true, mergedPropertiesMap is empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator, "clusterEnabled",
@@ -396,8 +392,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 
 		Assert.assertEquals(1, countGetDefaultPortalCacheConfiguration.get());
 
-		// test case3: clusterEnabled is true, _bootstrapLoaderProperties and
-		// _replicatorProperties are both setted a non-empty properties
+		// Test 3: clusterEnabled is true, _bootstrapLoaderProperties and
+		// _replicatorProperties are non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -486,9 +482,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 			Assert.assertEquals(1, count);
 		}
 
-		// test case4: clusterEnabled and _bootstrapLoaderEnabled are true,
-		// _bootstrapLoaderProperties is setted an empty properties,
-		// _replicatorProperties is setted a non-empty properties
+		// Test 4: clusterEnabled and _bootstrapLoaderEnabled are true,
+		// _bootstrapLoaderProperties is empty, _replicatorProperties non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -537,9 +532,9 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 				(boolean)properties.get(PortalCacheReplicator.REPLICATOR));
 		}
 
-		// test case5: clusterEnabled is true, _bootstrapLoaderEnabled is false,
-		// _bootstrapLoaderProperties is setted an empty properties,
-		// _replicatorProperties is setted a non-empty properties
+		// Test 5: clusterEnabled is true, _bootstrapLoaderEnabled is false,
+		// _bootstrapLoaderProperties is empty, _replicatorProperties is
+		// non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -591,9 +586,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 				(boolean)properties.get(PortalCacheReplicator.REPLICATOR));
 		}
 
-		// test case6: clusterEnabled is true, _bootstrapLoaderEnabled is true,
-		// _bootstrapLoaderProperties is setted a non-empty properties,
-		// _replicatorProperties is setted an empty properties
+		// Test 6: clusterEnabled is true, _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties non-empty, _replicatorProperties is empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -638,9 +632,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 			Assert.assertNull(propertiesPair.getValue());
 		}
 
-		// test case6: clusterEnabled is true, _bootstrapLoaderEnabled is true,
-		// _bootstrapLoaderProperties and _replicatorProperties are both setted
-		// a non-empty properties
+		// Test 7: clusterEnabled is true, _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties and _replicatorProperties are non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -703,9 +696,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 	public void testParseCacheListenerConfigurations() {
 		_activate(false, true);
 
-		// test case1: clusterEnabled is false, _bootstrapLoaderEnabled is true,
-		// _bootstrapLoaderProperties and _replicatorProperties are setted an
-		// empty properties
+		// Test 1: clusterEnabled is false, _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties and _replicatorProperties are empty
 
 		CacheConfiguration cacheConfiguration = new CacheConfiguration();
 
@@ -724,9 +716,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 				portalCacheConfiguration.
 					getPortalCacheListenerPropertiesSet()));
 
-		// test case2: clusterEnabled and _bootstrapLoaderEnabled are true,
-		// _bootstrapLoaderProperties and _replicatorProperties are setted an
-		// empty properties
+		// Test 2: clusterEnabled and _bootstrapLoaderEnabled are true,
+		// _bootstrapLoaderProperties and _replicatorProperties are empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator, "clusterEnabled",
@@ -773,9 +764,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 				(Boolean)properties.get(PortalCacheReplicator.REPLICATOR));
 		}
 
-		// test case3: clusterEnabled is true, _bootstrapLoaderEnabled is false,
-		// _bootstrapLoaderProperties and _replicatorProperties are setted an
-		// empty properties
+		// Test 3: clusterEnabled is true, _bootstrapLoaderEnabled is false,
+		// _bootstrapLoaderProperties and _replicatorProperties are empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,
@@ -813,9 +803,8 @@ public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
 				(Boolean)properties.get(PortalCacheReplicator.REPLICATOR));
 		}
 
-		// test case4: clusterEnabled and _bootstrapLoaderEnabled are true,
-		// _bootstrapLoaderProperties and _replicatorProperties are setted a
-		// non-empty properties
+		// Test 4: clusterEnabled and _bootstrapLoaderEnabled are true,
+		// _bootstrapLoaderProperties and _replicatorProperties are non-empty
 
 		ReflectionTestUtil.setFieldValue(
 			_multiVMEhcachePortalCacheManagerConfigurator,

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/MultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -1,0 +1,902 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.cache.ehcache.internal.configurator;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.cache.PortalCacheReplicator;
+import com.liferay.portal.cache.configuration.PortalCacheConfiguration;
+import com.liferay.portal.cache.configuration.PortalCacheManagerConfiguration;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.Configuration;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Leon Chi
+ */
+public class MultiVMEhcachePortalCacheManagerConfiguratorTest {
+
+	@ClassRule
+	public static final CodeCoverageAssertor codeCoverageAssertor =
+		CodeCoverageAssertor.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_multiVMEhcachePortalCacheManagerConfigurator =
+			new MultiVMEhcachePortalCacheManagerConfigurator();
+	}
+
+	@Test
+	public void testActivate() {
+		_activate(true, true);
+
+		boolean bootstrapLoaderEnabled = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled");
+		Properties bootstrapLoaderProperties = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties");
+		boolean clusterEnabled = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator, "clusterEnabled");
+		String defaultBootstrapLoaderPropertiesString =
+			ReflectionTestUtil.getFieldValue(
+				_multiVMEhcachePortalCacheManagerConfigurator,
+				"_defaultBootstrapLoaderPropertiesString");
+		String defaultReplicatorPropertiesString =
+			ReflectionTestUtil.getFieldValue(
+				_multiVMEhcachePortalCacheManagerConfigurator,
+				"_defaultReplicatorPropertiesString");
+		Properties replicatorProperties = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties");
+
+		Assert.assertTrue(bootstrapLoaderEnabled);
+		Assert.assertEquals(
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE,
+			bootstrapLoaderProperties);
+		Assert.assertTrue(clusterEnabled);
+		Assert.assertEquals(
+			StringUtil.merge(
+				PropsInvocationHandler.
+					EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT_VALUE,
+				StringPool.COMMA),
+			defaultBootstrapLoaderPropertiesString);
+		Assert.assertEquals(
+			StringUtil.merge(
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE,
+				StringPool.COMMA),
+			defaultReplicatorPropertiesString);
+		Assert.assertEquals(
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE,
+			replicatorProperties);
+	}
+
+	@Test
+	public void testGetMergedPropertiesMap() {
+		_activate(true, true);
+
+		// test case1: _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties and _replicatorProperties are both setted
+		// an empty properties
+
+		Map<String, ObjectValuePair<Properties, Properties>>
+			mergedPropertiesMap = ReflectionTestUtil.invoke(
+				_multiVMEhcachePortalCacheManagerConfigurator,
+				"_getMergedPropertiesMap", null, null);
+
+		Assert.assertTrue(MapUtil.isEmpty(mergedPropertiesMap));
+
+		// test case2: _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties and _replicatorProperties are both setted
+		// a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		Set<String> keySet = mergedPropertiesMap.keySet();
+
+		Assert.assertTrue(
+			keySet.containsAll(
+				PropsInvocationHandler.
+					EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1.keySet()));
+		Assert.assertTrue(
+			keySet.containsAll(
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_VALUE1.keySet()));
+
+		Set<Map.Entry<String, ObjectValuePair<Properties, Properties>>>
+			entrySet = mergedPropertiesMap.entrySet();
+
+		Assert.assertEquals(entrySet.toString(), 3, entrySet.size());
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				entrySet) {
+
+			String key = entry.getKey();
+
+			ObjectValuePair objectValuePair = entry.getValue();
+
+			Properties keyProperties = (Properties)objectValuePair.getKey();
+
+			String bootstrapLoaderPropertiesValue =
+				PropsInvocationHandler.
+					EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1.
+						getProperty(key);
+
+			Assert.assertEquals(
+				"", keyProperties.getProperty(bootstrapLoaderPropertiesValue));
+
+			Properties valueProperties = (Properties)objectValuePair.getValue();
+			String replicatorPropertiesValue =
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_VALUE1.getProperty(key);
+
+			Assert.assertEquals(
+				"", valueProperties.getProperty(replicatorPropertiesValue));
+
+			Assert.assertTrue((boolean)valueProperties.get("replicator"));
+		}
+
+		// test case3: _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties is setted an empty properties,
+		// _replicatorProperties is setted a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		keySet = mergedPropertiesMap.keySet();
+
+		Assert.assertTrue(
+			keySet.containsAll(
+				PropsInvocationHandler.
+					EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE.keySet()));
+		Assert.assertTrue(
+			keySet.containsAll(
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_VALUE1.keySet()));
+
+		entrySet = mergedPropertiesMap.entrySet();
+
+		Assert.assertEquals(entrySet.toString(), 3, entrySet.size());
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				entrySet) {
+
+			String key = entry.getKey();
+
+			ObjectValuePair objectValuePair = entry.getValue();
+
+			Properties keyProperties = (Properties)objectValuePair.getKey();
+
+			Assert.assertNull(keyProperties);
+
+			Properties valueProperties = (Properties)objectValuePair.getValue();
+			String replicatorPropertiesValue =
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_VALUE1.getProperty(key);
+
+			Assert.assertEquals(
+				"", valueProperties.getProperty(replicatorPropertiesValue));
+
+			Assert.assertTrue((boolean)valueProperties.get("replicator"));
+		}
+
+		// test case4: _bootstrapLoaderEnabled is false,
+		// _bootstrapLoaderProperties and _replicatorProperties are both setted
+		// a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled", false);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		keySet = mergedPropertiesMap.keySet();
+
+		Assert.assertTrue(
+			keySet.containsAll(
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_VALUE1.keySet()));
+
+		entrySet = mergedPropertiesMap.entrySet();
+
+		Assert.assertEquals(entrySet.toString(), 3, entrySet.size());
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				entrySet) {
+
+			String key = entry.getKey();
+
+			ObjectValuePair objectValuePair = entry.getValue();
+
+			Properties keyProperties = (Properties)objectValuePair.getKey();
+
+			Assert.assertNull(keyProperties);
+
+			Properties valueProperties = (Properties)objectValuePair.getValue();
+			String replicatorPropertiesValue =
+				PropsInvocationHandler.
+					EHCACHE_REPLICATOR_PROPERTIES_VALUE1.getProperty(key);
+
+			Assert.assertEquals(
+				"", valueProperties.getProperty(replicatorPropertiesValue));
+
+			Assert.assertTrue((boolean)valueProperties.get("replicator"));
+		}
+	}
+
+	@Test
+	public void testGetPortalPropertiesString() {
+		_activate(true, true);
+
+		String portalPropertiesString =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				getPortalPropertiesString(
+					PropsInvocationHandler.PORTAL_PROPERTY_KEY0);
+
+		Assert.assertNull(portalPropertiesString);
+
+		portalPropertiesString =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				getPortalPropertiesString(
+					PropsInvocationHandler.PORTAL_PROPERTY_KEY1);
+
+		Assert.assertSame(
+			PropsInvocationHandler.ARRAY_1[0], portalPropertiesString);
+
+		portalPropertiesString =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				getPortalPropertiesString(
+					PropsInvocationHandler.PORTAL_PROPERTY_KEY2);
+
+		Assert.assertEquals(
+			StringUtil.merge(PropsInvocationHandler.ARRAY_2, StringPool.COMMA),
+			portalPropertiesString);
+	}
+
+	@Test
+	public void testIsRequireSerialization() {
+		_activate(true, true);
+
+		CacheConfiguration cacheConfiguration = new CacheConfiguration();
+
+		Assert.assertTrue(
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				isRequireSerialization(cacheConfiguration));
+
+		_activate(false, true);
+
+		Assert.assertFalse(
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				isRequireSerialization(cacheConfiguration));
+	}
+
+	@Test
+	public void testManageConfiguration() {
+		_activate(false, true);
+
+		// test case1: clusterEnabled is false
+
+		Configuration configuration = new Configuration();
+
+		final AtomicBoolean calledGetDefaultPortalCacheConfiguration =
+			new AtomicBoolean(false);
+
+		PortalCacheManagerConfiguration portalCacheManagerConfiguration =
+			new PortalCacheManagerConfiguration(null, null, null) {
+
+				@Override
+				public PortalCacheConfiguration
+					getDefaultPortalCacheConfiguration() {
+
+					calledGetDefaultPortalCacheConfiguration.set(true);
+
+					return null;
+				}
+
+			};
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		Assert.assertFalse(calledGetDefaultPortalCacheConfiguration.get());
+
+		// test case2: clusterEnabled is true, mergedPropertiesMap is empty
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator, "clusterEnabled",
+			true);
+
+		final AtomicInteger countGetDefaultPortalCacheConfiguration =
+			new AtomicInteger(0);
+
+		portalCacheManagerConfiguration =
+			new PortalCacheManagerConfiguration(null, null, null) {
+
+				@Override
+				public PortalCacheConfiguration
+					getDefaultPortalCacheConfiguration() {
+
+					countGetDefaultPortalCacheConfiguration.addAndGet(1);
+
+					return null;
+				}
+
+			};
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		Assert.assertEquals(1, countGetDefaultPortalCacheConfiguration.get());
+
+		// test case3: clusterEnabled is true, _bootstrapLoaderProperties and
+		// _replicatorProperties are both setted a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		Set<Properties> portalCacheListenerPropertiesSet = new HashSet<>();
+
+		Properties properties = new Properties();
+
+		properties.put(PortalCacheReplicator.REPLICATOR, true);
+
+		portalCacheListenerPropertiesSet.add(properties);
+
+		properties = new Properties();
+
+		properties.put(PortalCacheReplicator.REPLICATOR, false);
+
+		portalCacheListenerPropertiesSet.add(properties);
+
+		PortalCacheConfiguration defaultPortalCacheConfiguration =
+			new PortalCacheConfiguration(
+				PortalCacheConfiguration.PORTAL_CACHE_NAME_DEFAULT,
+				portalCacheListenerPropertiesSet, null);
+
+		portalCacheManagerConfiguration = new PortalCacheManagerConfiguration(
+			null, defaultPortalCacheConfiguration, null);
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		Map<String, ObjectValuePair<Properties, Properties>>
+			mergedPropertiesMap = ReflectionTestUtil.invoke(
+				_multiVMEhcachePortalCacheManagerConfigurator,
+				"_getMergedPropertiesMap", null, null);
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				mergedPropertiesMap.entrySet()) {
+
+			String portalCacheName = entry.getKey();
+
+			PortalCacheConfiguration portalCacheConfiguration =
+				portalCacheManagerConfiguration.getPortalCacheConfiguration(
+					portalCacheName);
+
+			ObjectValuePair<Properties, Properties> propertiesPair =
+				entry.getValue();
+
+			Assert.assertEquals(
+				propertiesPair.getKey(),
+				portalCacheConfiguration.
+					getPortalCacheBootstrapLoaderProperties());
+
+			portalCacheListenerPropertiesSet =
+				portalCacheConfiguration.getPortalCacheListenerPropertiesSet();
+
+			Assert.assertTrue(
+				portalCacheListenerPropertiesSet.contains(
+					propertiesPair.getValue()));
+
+			properties = propertiesPair.getValue();
+
+			Assert.assertTrue(
+				(boolean)properties.get(PortalCacheReplicator.REPLICATOR));
+
+			Iterator<Properties> itr =
+				portalCacheListenerPropertiesSet.iterator();
+
+			int count = 0;
+
+			while (itr.hasNext()) {
+				properties = itr.next();
+
+				Object value = properties.get(PortalCacheReplicator.REPLICATOR);
+
+				if ((value != null) && (Boolean)value) {
+					count++;
+				}
+			}
+
+			Assert.assertEquals(1, count);
+		}
+
+		// test case4: clusterEnabled and _bootstrapLoaderEnabled are true,
+		// _bootstrapLoaderProperties is setted an empty properties,
+		// _replicatorProperties is setted a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		portalCacheManagerConfiguration = new PortalCacheManagerConfiguration(
+			null, defaultPortalCacheConfiguration, null);
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				mergedPropertiesMap.entrySet()) {
+
+			String portalCacheName = entry.getKey();
+
+			PortalCacheConfiguration portalCacheConfiguration =
+				portalCacheManagerConfiguration.getPortalCacheConfiguration(
+					portalCacheName);
+
+			ObjectValuePair<Properties, Properties> propertiesPair =
+				entry.getValue();
+
+			Assert.assertNull(propertiesPair.getKey());
+
+			portalCacheListenerPropertiesSet =
+				portalCacheConfiguration.getPortalCacheListenerPropertiesSet();
+
+			Assert.assertTrue(
+				portalCacheListenerPropertiesSet.contains(
+					propertiesPair.getValue()));
+
+			properties = propertiesPair.getValue();
+
+			Assert.assertTrue(
+				(boolean)properties.get(PortalCacheReplicator.REPLICATOR));
+		}
+
+		// test case5: clusterEnabled is true, _bootstrapLoaderEnabled is false,
+		// _bootstrapLoaderProperties is setted an empty properties,
+		// _replicatorProperties is setted a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled", false);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		portalCacheManagerConfiguration = new PortalCacheManagerConfiguration(
+			null, defaultPortalCacheConfiguration, null);
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				mergedPropertiesMap.entrySet()) {
+
+			String portalCacheName = entry.getKey();
+
+			PortalCacheConfiguration portalCacheConfiguration =
+				portalCacheManagerConfiguration.getPortalCacheConfiguration(
+					portalCacheName);
+
+			ObjectValuePair<Properties, Properties> propertiesPair =
+				entry.getValue();
+
+			Assert.assertNull(propertiesPair.getKey());
+
+			portalCacheListenerPropertiesSet =
+				portalCacheConfiguration.getPortalCacheListenerPropertiesSet();
+
+			Assert.assertTrue(
+				portalCacheListenerPropertiesSet.contains(
+					propertiesPair.getValue()));
+
+			properties = propertiesPair.getValue();
+
+			Assert.assertTrue(
+				(boolean)properties.get(PortalCacheReplicator.REPLICATOR));
+		}
+
+		// test case6: clusterEnabled is true, _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties is setted a non-empty properties,
+		// _replicatorProperties is setted an empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled", true);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE);
+
+		portalCacheManagerConfiguration = new PortalCacheManagerConfiguration(
+			null, defaultPortalCacheConfiguration, null);
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				mergedPropertiesMap.entrySet()) {
+
+			String portalCacheName = entry.getKey();
+
+			PortalCacheConfiguration portalCacheConfiguration =
+				portalCacheManagerConfiguration.getPortalCacheConfiguration(
+					portalCacheName);
+
+			ObjectValuePair<Properties, Properties> propertiesPair =
+				entry.getValue();
+
+			Assert.assertEquals(
+				propertiesPair.getKey(),
+				portalCacheConfiguration.
+					getPortalCacheBootstrapLoaderProperties());
+
+			Assert.assertNull(propertiesPair.getValue());
+		}
+
+		// test case6: clusterEnabled is true, _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties and _replicatorProperties are both setted
+		// a non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled", true);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		final AtomicBoolean calledNewPortalCacheConfiguration =
+			new AtomicBoolean(false);
+
+		defaultPortalCacheConfiguration = new PortalCacheConfiguration(
+			PortalCacheConfiguration.PORTAL_CACHE_NAME_DEFAULT,
+			portalCacheListenerPropertiesSet, null) {
+
+			@Override
+			public PortalCacheConfiguration newPortalCacheConfiguration(
+				String portalCacheName) {
+
+				calledNewPortalCacheConfiguration.set(true);
+
+				return null;
+			}
+
+		};
+
+		portalCacheManagerConfiguration = new PortalCacheManagerConfiguration(
+			null, defaultPortalCacheConfiguration, null);
+
+		mergedPropertiesMap = ReflectionTestUtil.invoke(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_getMergedPropertiesMap", null, null);
+
+		for (Map.Entry<String, ObjectValuePair<Properties, Properties>> entry :
+				mergedPropertiesMap.entrySet()) {
+
+			String portalCacheName = entry.getKey();
+
+			PortalCacheConfiguration portalCacheConfiguration =
+				new PortalCacheConfiguration(
+					portalCacheName, portalCacheListenerPropertiesSet, null);
+
+			portalCacheManagerConfiguration.putPortalCacheConfiguration(
+				portalCacheName, portalCacheConfiguration);
+		}
+
+		_multiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		Assert.assertFalse(calledNewPortalCacheConfiguration.get());
+	}
+
+	@Test
+	public void testParseCacheListenerConfigurations() {
+		_activate(false, true);
+
+		// test case1: clusterEnabled is false, _bootstrapLoaderEnabled is true,
+		// _bootstrapLoaderProperties and _replicatorProperties are setted an
+		// empty properties
+
+		CacheConfiguration cacheConfiguration = new CacheConfiguration();
+
+		cacheConfiguration.setName("TestName");
+
+		PortalCacheConfiguration portalCacheConfiguration =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				parseCacheListenerConfigurations(cacheConfiguration, true);
+
+		Assert.assertEquals(
+			"TestName", portalCacheConfiguration.getPortalCacheName());
+		Assert.assertNull(
+			portalCacheConfiguration.getPortalCacheBootstrapLoaderProperties());
+		Assert.assertTrue(
+			SetUtil.isEmpty(
+				portalCacheConfiguration.
+					getPortalCacheListenerPropertiesSet()));
+
+		// test case2: clusterEnabled and _bootstrapLoaderEnabled are true,
+		// _bootstrapLoaderProperties and _replicatorProperties are setted an
+		// empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator, "clusterEnabled",
+			true);
+
+		portalCacheConfiguration =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				parseCacheListenerConfigurations(cacheConfiguration, true);
+
+		Assert.assertEquals(
+			"TestName", portalCacheConfiguration.getPortalCacheName());
+
+		Properties bootstrapLoaderProperties =
+			_multiVMEhcachePortalCacheManagerConfigurator.parseProperties(
+				StringUtil.merge(
+					PropsInvocationHandler.
+						EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT_VALUE,
+					StringPool.COMMA),
+				StringPool.COMMA);
+
+		Assert.assertEquals(
+			bootstrapLoaderProperties,
+			portalCacheConfiguration.getPortalCacheBootstrapLoaderProperties());
+
+		Properties replicatorProperties =
+			_multiVMEhcachePortalCacheManagerConfigurator.parseProperties(
+				StringUtil.merge(
+					PropsInvocationHandler.
+						EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE,
+					StringPool.COMMA),
+				StringPool.COMMA);
+		Set<Properties> portalCacheListenerPropertiesSet =
+			portalCacheConfiguration.getPortalCacheListenerPropertiesSet();
+
+		for (Properties properties : portalCacheListenerPropertiesSet) {
+			for (Object key : replicatorProperties.keySet()) {
+				Object replicatorValue = replicatorProperties.get(key);
+				Object value = properties.get(key);
+
+				Assert.assertEquals(replicatorValue, value);
+			}
+
+			Assert.assertTrue(
+				(Boolean)properties.get(PortalCacheReplicator.REPLICATOR));
+		}
+
+		// test case3: clusterEnabled is true, _bootstrapLoaderEnabled is false,
+		// _bootstrapLoaderProperties and _replicatorProperties are setted an
+		// empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled", false);
+
+		portalCacheConfiguration =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				parseCacheListenerConfigurations(cacheConfiguration, true);
+
+		Assert.assertEquals(
+			"TestName", portalCacheConfiguration.getPortalCacheName());
+
+		Assert.assertNull(
+			portalCacheConfiguration.getPortalCacheBootstrapLoaderProperties());
+
+		replicatorProperties =
+			_multiVMEhcachePortalCacheManagerConfigurator.parseProperties(
+				StringUtil.merge(
+					PropsInvocationHandler.
+						EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE,
+					StringPool.COMMA),
+				StringPool.COMMA);
+		portalCacheListenerPropertiesSet =
+			portalCacheConfiguration.getPortalCacheListenerPropertiesSet();
+
+		for (Properties properties : portalCacheListenerPropertiesSet) {
+			for (Object key : replicatorProperties.keySet()) {
+				Object replicatorValue = replicatorProperties.get(key);
+				Object value = properties.get(key);
+
+				Assert.assertEquals(replicatorValue, value);
+			}
+
+			Assert.assertTrue(
+				(Boolean)properties.get(PortalCacheReplicator.REPLICATOR));
+		}
+
+		// test case4: clusterEnabled and _bootstrapLoaderEnabled are true,
+		// _bootstrapLoaderProperties and _replicatorProperties are setted a
+		// non-empty properties
+
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderEnabled", true);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties",
+			PropsInvocationHandler.
+				EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1);
+		ReflectionTestUtil.setFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties",
+			PropsInvocationHandler.EHCACHE_REPLICATOR_PROPERTIES_VALUE1);
+
+		cacheConfiguration = new CacheConfiguration();
+
+		cacheConfiguration.setName("name1");
+
+		portalCacheConfiguration =
+			_multiVMEhcachePortalCacheManagerConfigurator.
+				parseCacheListenerConfigurations(cacheConfiguration, true);
+
+		bootstrapLoaderProperties = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_bootstrapLoaderProperties");
+		replicatorProperties = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator,
+			"_replicatorProperties");
+
+		Assert.assertNull(bootstrapLoaderProperties.get("name1"));
+		Assert.assertNull(replicatorProperties.get("name1"));
+		Assert.assertEquals(
+			"name1", portalCacheConfiguration.getPortalCacheName());
+
+		Properties portalCacheBootstrapLoaderProperties =
+			portalCacheConfiguration.getPortalCacheBootstrapLoaderProperties();
+
+		Assert.assertEquals(
+			"", portalCacheBootstrapLoaderProperties.get("value1"));
+
+		portalCacheListenerPropertiesSet =
+			portalCacheConfiguration.getPortalCacheListenerPropertiesSet();
+
+		for (Properties properties : portalCacheListenerPropertiesSet) {
+			Assert.assertEquals("", properties.get("value1"));
+
+			Assert.assertTrue(
+				(Boolean)properties.get(PortalCacheReplicator.REPLICATOR));
+		}
+	}
+
+	@Test
+	public void testSetProps() {
+		Props proxyProps = (Props)ProxyUtil.newProxyInstance(
+			_classLoader, new Class<?>[] {Props.class},
+			new PropsInvocationHandler(true, true));
+
+		_multiVMEhcachePortalCacheManagerConfigurator.setProps(proxyProps);
+
+		Props proxy = ReflectionTestUtil.getFieldValue(
+			_multiVMEhcachePortalCacheManagerConfigurator, "props");
+
+		Assert.assertSame(proxyProps, proxy);
+	}
+
+	private void _activate(
+		boolean clusterEnabled, boolean bootstrapLoaderEnabled) {
+
+		Props proxyProps = (Props)ProxyUtil.newProxyInstance(
+			_classLoader, new Class<?>[] {Props.class},
+			new PropsInvocationHandler(clusterEnabled, bootstrapLoaderEnabled));
+
+		_multiVMEhcachePortalCacheManagerConfigurator.setProps(proxyProps);
+
+		_multiVMEhcachePortalCacheManagerConfigurator.activate();
+	}
+
+	private static final ClassLoader _classLoader =
+		MultiVMEhcachePortalCacheManagerConfiguratorTest.class.getClassLoader();
+
+	private MultiVMEhcachePortalCacheManagerConfigurator
+		_multiVMEhcachePortalCacheManagerConfigurator;
+
+}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/PropsInvocationHandler.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/PropsInvocationHandler.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.cache.ehcache.internal.configurator;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.PropsKeys;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import java.util.Properties;
+
+/**
+ * @author Leon Chi
+ */
+public class PropsInvocationHandler implements InvocationHandler {
+
+	public static final String[] ARRAY_0 = {};
+
+	public static final String[] ARRAY_1 = {"value"};
+
+	public static final String[] ARRAY_2 = {"value1", "value2"};
+
+	public static final String[]
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT_VALUE =
+			{"value5", "value6"};
+
+	public static final Properties
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE = new Properties();
+
+	public static final Properties
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1 = new Properties();
+
+	public static final String[] EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE =
+		{"value7", "value8"};
+
+	public static final Properties EHCACHE_REPLICATOR_PROPERTIES_VALUE =
+		new Properties();
+
+	public static final Properties EHCACHE_REPLICATOR_PROPERTIES_VALUE1 =
+		new Properties();
+
+	public static final String EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE =
+		"ehcache.rmi.peer.listener.factory.class.value";
+
+	public static final String[]
+		EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE =
+			{"value1", "value2"};
+
+	public static final String EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE =
+		"ehcache.rmi.peer.provider.factory.class.value";
+
+	public static final String[]
+		EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE =
+			{"value3", "value4"};
+
+	public static final String PORTAL_PROPERTY_KEY0 = "portal.property.Key0";
+
+	public static final String PORTAL_PROPERTY_KEY1 = "portal.property.Key1";
+
+	public static final String PORTAL_PROPERTY_KEY2 = "portal.property.Key2";
+
+	static {
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1.setProperty(
+			"name1", "value1");
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1.setProperty(
+			"name2", "value2");
+		EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE1.setProperty(
+			"name3", "value3");
+
+		EHCACHE_REPLICATOR_PROPERTIES_VALUE1.setProperty("name1", "value1");
+		EHCACHE_REPLICATOR_PROPERTIES_VALUE1.setProperty("name2", "value2");
+		EHCACHE_REPLICATOR_PROPERTIES_VALUE1.setProperty("name3", "value3");
+	}
+
+	public PropsInvocationHandler(boolean clusterEnabled) {
+		_clusterEnabled = clusterEnabled;
+	}
+
+	public PropsInvocationHandler(
+		boolean clusterEnabled, boolean bootstrapLoaderEnabled) {
+
+		_clusterEnabled = clusterEnabled;
+		_bootstrapLoaderEnabled = bootstrapLoaderEnabled;
+	}
+
+	@Override
+	public Object invoke(Object proxy, Method method, Object[] args) {
+		String methodName = method.getName();
+
+		if (methodName.equals("get")) {
+			String key = (String)args[0];
+
+			if (PropsKeys.EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS.equals(key)) {
+				return EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS.equals(key)) {
+				return EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE;
+			}
+
+			if (PropsKeys.CLUSTER_LINK_ENABLED.equals(key)) {
+				if (_clusterEnabled) {
+					return "true";
+				}
+				else {
+					return "false";
+				}
+			}
+
+			if (PropsKeys.EHCACHE_BOOTSTRAP_CACHE_LOADER_ENABLED.equals(key)) {
+				if (_bootstrapLoaderEnabled) {
+					return "true";
+				}
+				else {
+					return "false";
+				}
+			}
+		}
+
+		if (methodName.equals("getArray")) {
+			String key = (String)args[0];
+
+			if (PropsKeys.EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES.equals(
+					key)) {
+
+				return EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES.equals(
+					key)) {
+
+				return EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT.
+					equals(key)) {
+
+				return EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_DEFAULT_VALUE;
+			}
+
+			if (PropsKeys.EHCACHE_REPLICATOR_PROPERTIES_DEFAULT.equals(key)) {
+				return EHCACHE_REPLICATOR_PROPERTIES_DEFAULT_VALUE;
+			}
+
+			if (PORTAL_PROPERTY_KEY0.equals(key)) {
+				return ARRAY_0;
+			}
+
+			if (PORTAL_PROPERTY_KEY1.equals(key)) {
+				return ARRAY_1;
+			}
+
+			if (PORTAL_PROPERTY_KEY2.equals(key)) {
+				return ARRAY_2;
+			}
+		}
+
+		if (methodName.equals("getProperties")) {
+			String key = (String)args[0];
+
+			if (key.equals(
+					PropsKeys.EHCACHE_REPLICATOR_PROPERTIES +
+						StringPool.PERIOD)) {
+
+				return EHCACHE_REPLICATOR_PROPERTIES_VALUE;
+			}
+
+			if (key.equals(
+					PropsKeys.EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES +
+						StringPool.PERIOD)) {
+
+				return EHCACHE_BOOTSTRAP_CACHE_LOADER_PROPERTIES_VALUE;
+			}
+		}
+
+		return null;
+	}
+
+	private boolean _bootstrapLoaderEnabled;
+	private final boolean _clusterEnabled;
+
+}

--- a/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
+++ b/modules/apps/portal-cache/portal-cache-ehcache-impl/src/test/java/com/liferay/portal/cache/ehcache/internal/configurator/RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.cache.ehcache.internal.configurator;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.cache.configuration.PortalCacheManagerConfiguration;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.List;
+
+import net.sf.ehcache.config.Configuration;
+import net.sf.ehcache.config.FactoryConfiguration;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Leon Chi
+ */
+public class RMIMultiVMEhcachePortalCacheManagerConfiguratorTest {
+
+	@ClassRule
+	public static final CodeCoverageAssertor codeCoverageAssertor =
+		CodeCoverageAssertor.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator =
+			new RMIMultiVMEhcachePortalCacheManagerConfigurator();
+	}
+
+	@Test
+	public void testActivate() {
+		_activate(false);
+
+		String peerListenerFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerListenerFactoryClass");
+		String peerListenerFactoryPropertiesString =
+			ReflectionTestUtil.getFieldValue(
+				_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+				"_peerListenerFactoryPropertiesString");
+		String peerProviderFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerProviderFactoryClass");
+		String peerProviderFactoryPropertiesString =
+			ReflectionTestUtil.getFieldValue(
+				_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+				"_peerProviderFactoryPropertiesString");
+
+		Assert.assertNull(peerListenerFactoryClass);
+		Assert.assertNull(peerListenerFactoryPropertiesString);
+		Assert.assertNull(peerProviderFactoryClass);
+		Assert.assertNull(peerProviderFactoryPropertiesString);
+
+		_activate(true);
+
+		peerListenerFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerListenerFactoryClass");
+		peerListenerFactoryPropertiesString = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerListenerFactoryPropertiesString");
+		peerProviderFactoryClass = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerProviderFactoryClass");
+		peerProviderFactoryPropertiesString = ReflectionTestUtil.getFieldValue(
+			_rmiMultiVMEhcachePortalCacheManagerConfigurator,
+			"_peerProviderFactoryPropertiesString");
+
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE,
+			peerProviderFactoryClass);
+		Assert.assertEquals(
+			StringUtil.merge(PropsInvocationHandler.
+				EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE,
+				StringPool.COMMA),
+			peerListenerFactoryPropertiesString);
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE,
+			peerListenerFactoryClass);
+		Assert.assertEquals(
+			StringUtil.merge(PropsInvocationHandler.
+				EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE,
+				StringPool.COMMA),
+			peerProviderFactoryPropertiesString);
+	}
+
+	@Test
+	public void testManageConfiguration() {
+		Configuration configuration = new Configuration();
+
+		PortalCacheManagerConfiguration portalCacheManagerConfiguration =
+			new PortalCacheManagerConfiguration(null, null, null);
+
+		_activate(false);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				configuration.
+					getCacheManagerPeerProviderFactoryConfiguration()));
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				configuration.
+					getCacheManagerPeerListenerFactoryConfigurations()));
+
+		_activate(true);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.manageConfiguration(
+			configuration, portalCacheManagerConfiguration);
+
+		List<FactoryConfiguration>
+			cacheManagerPeerProviderFactoryConfigurations =
+				configuration.getCacheManagerPeerProviderFactoryConfiguration();
+
+		FactoryConfiguration peerProviderFactoryConfiguration =
+			cacheManagerPeerProviderFactoryConfigurations.get(0);
+
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_PROVIDER_FACTORY_CLASS_VALUE,
+			peerProviderFactoryConfiguration.getFullyQualifiedClassPath());
+		Assert.assertEquals(
+			StringUtil.merge(PropsInvocationHandler.
+				EHCACHE_RMI_PEER_PROVIDER_FACTORY_PROPERTIES_VALUE,
+				StringPool.COMMA),
+			peerProviderFactoryConfiguration.getProperties());
+		Assert.assertSame(
+			StringPool.COMMA,
+			peerProviderFactoryConfiguration.getPropertySeparator());
+
+		List<FactoryConfiguration>
+			cacheManagerPeerListenerFactoryConfigurations =
+				configuration.
+					getCacheManagerPeerListenerFactoryConfigurations();
+
+		FactoryConfiguration peerListenerFacotryConfiguration =
+			cacheManagerPeerListenerFactoryConfigurations.get(0);
+
+		Assert.assertSame(
+			PropsInvocationHandler.
+				EHCACHE_RMI_PEER_LISTENER_FACTORY_CLASS_VALUE,
+			peerListenerFacotryConfiguration.getFullyQualifiedClassPath());
+		Assert.assertEquals(
+			StringUtil.merge(
+				PropsInvocationHandler.
+					EHCACHE_RMI_PEER_LISTENER_FACTORY_PROPERTIES_VALUE,
+				StringPool.COMMA),
+			peerListenerFacotryConfiguration.getProperties());
+		Assert.assertSame(
+			StringPool.COMMA,
+			peerListenerFacotryConfiguration.getPropertySeparator());
+	}
+
+	private void _activate(boolean clusterEnabled) {
+		Props proxyProps = (Props)ProxyUtil.newProxyInstance(
+			_classLoader, new Class<?>[] {Props.class},
+			new PropsInvocationHandler(clusterEnabled));
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.setProps(proxyProps);
+
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator.activate();
+	}
+
+	private static final ClassLoader _classLoader =
+		RMIMultiVMEhcachePortalCacheManagerConfiguratorTest.class.
+			getClassLoader();
+
+	private RMIMultiVMEhcachePortalCacheManagerConfigurator
+		_rmiMultiVMEhcachePortalCacheManagerConfigurator;
+
+}


### PR DESCRIPTION
@ChiZeLin There are too many constants in the PropsInvocationHandler. Are there constants that are not returned directly by calling Props methods? If so, could you move those to the corresponding test class? Also, I'm wondering if there's a better way for some of the tests, where you just replace the field value of the configurator for different scenarios. I would always prefer doing it by re-construct and activate the configurator class, which is more suitable for the configurator's real world usage. However, if it makes the test too complicated, I can bear with the current ones.